### PR TITLE
Muvi 113/museum crud

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,8 @@ import tourRoutes from "./routes/tour.routes";
 import preferenceRoutes from "./routes/preference.routes";
 import userRoutes from "./routes/user.routes";
 import reviewsRoutes from "./routes/reviews.routes";
+import museumsRoutes from "./routes/museums.routes";
+// middlewares
 import { AuthMiddleware } from "./middlewares";
 
 const app = express();
@@ -53,6 +55,7 @@ app.use("/api/tour", tourRoutes);
 app.use("/api/preference", preferenceRoutes);
 app.use("/api/user", userRoutes);
 app.use("/api/reviews", reviewsRoutes)
+app.use("/api/museums", museumsRoutes);
 
 app.get("/", AuthMiddleware,(req: Request, res: Response) => {
   res.send(JSON.stringify(req.user));

--- a/src/controllers/museums.controllers.ts
+++ b/src/controllers/museums.controllers.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import prisma from "../prisma";
+import { ResponseData } from "../types/ResponseData";
+import { Request, Response } from "express";
+import { EditMuseumSchema } from "../types/museums/ZodSchemas";
+import { emptyBodyResponse, invalidBodyResponse, notFoundResponse, validateEmptyBody, validateIdAndRespond } from "../utils/controllerUtils";
+
+export const getAllMuseumsController = async (req: Request, res: Response) => {
+  const museums = await prisma.museum.findMany({ orderBy: { created_at: "desc" } });
+  return res.status(200).json({
+    ok: true,
+    message: "Museums fetched successfully",
+    data: museums,
+  } as ResponseData);
+}
+
+export const getMuseumByIdController = async (req: Request, res: Response) => {
+  const idValidation = z.string().safeParse(req.params.id);
+  if (!idValidation.success)
+    return res.status(400).json({
+      ok: false,
+      message: "Invalid id",
+      errors: idValidation.error.format(),
+    } as unknown as ResponseData);
+  const id = idValidation.data;
+
+  const museum = await prisma.museum.findUnique({ where: { id } });
+
+  if (!museum)
+    return res.status(404).json({
+      ok: false,
+      message: "Museum not found",
+    } as ResponseData);
+
+  return res.status(200).json({
+    ok: true,
+    message: "Museum fetched successfully",
+    data: museum,
+  } as ResponseData);
+}
+
+export const editMuseumController = async (req: Request, res: Response) => {
+  validateIdAndRespond(res, req.params.id);
+  const id = req.params.id;
+
+  // Check if museum exists
+  const foundMuseum = await prisma.museum.findUnique({ where: { id } });
+  if (!foundMuseum) return notFoundResponse(res, "Museum");
+
+  // Validate body
+  const bodyValidation = EditMuseumSchema.safeParse(req.body);
+  if (!bodyValidation.success) return invalidBodyResponse(res, bodyValidation.error);
+
+  // validate at least one field is present
+  if (validateEmptyBody(bodyValidation.data)) return emptyBodyResponse(res);
+
+  // Filter only valid fields from the body
+  const validFields = Object.keys(bodyValidation.data).reduce(
+    (acc, key) => {
+      const typedKey = key as keyof typeof bodyValidation.data;
+      if (bodyValidation.data[typedKey] !== undefined) {
+        acc[typedKey] = bodyValidation.data[typedKey];
+      }
+      return acc;
+    },
+    {} as Partial<typeof bodyValidation.data>
+  );
+
+  // Update museum
+  const updatedMuseum = await prisma.museum.update({
+    where: { id },
+    data: validFields,
+  });
+
+  return res.status(200).json({
+    ok: true,
+    message: "Museum updated successfully",
+    data: updatedMuseum,
+  } as ResponseData);
+};

--- a/src/controllers/museums.controllers.ts
+++ b/src/controllers/museums.controllers.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import prisma from "../prisma";
 import { ResponseData } from "../types/ResponseData";
 import { Request, Response } from "express";
-import { EditMuseumSchema } from "../types/museums/ZodSchemas";
+import { CreateMuseumSchema, EditMuseumSchema } from "../types/museums/ZodSchemas";
 import { emptyBodyResponse, invalidBodyResponse, notFoundResponse, validateEmptyBody, validateIdAndRespond } from "../utils/controllerUtils";
 
 export const getAllMuseumsController = async (req: Request, res: Response) => {
@@ -35,6 +35,19 @@ export const getMuseumByIdController = async (req: Request, res: Response) => {
   return res.status(200).json({
     ok: true,
     message: "Museum fetched successfully",
+    data: museum,
+  } as ResponseData);
+}
+
+export const createMuseumController = async (req: Request, res: Response) => {
+  const bodyValidation = CreateMuseumSchema.safeParse(req.body);
+  if (!bodyValidation.success) return invalidBodyResponse(res, bodyValidation.error);
+
+  const museum = await prisma.museum.create({ data: bodyValidation.data });
+  
+  return res.status(201).json({
+    ok: true,
+    message: "Museum created successfully",
     data: museum,
   } as ResponseData);
 }

--- a/src/controllers/museums.controllers.ts
+++ b/src/controllers/museums.controllers.ts
@@ -91,3 +91,21 @@ export const editMuseumController = async (req: Request, res: Response) => {
     data: updatedMuseum,
   } as ResponseData);
 };
+
+export const deleteMuseumController = async (req: Request, res: Response) => {
+  validateIdAndRespond(res, req.params.id);
+  const id = req.params.id;
+
+  // Check if museum exists
+  const foundMuseum = await prisma.museum.findUnique({ where: { id } });
+  if (!foundMuseum) return notFoundResponse(res, "Museum");
+
+  // Delete museum
+  const deletedMuseum = await prisma.museum.delete({ where: { id } });
+
+  return res.status(200).json({
+    ok: true,
+    message: "Museum deleted successfully",
+    data: deletedMuseum,
+  } as ResponseData);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,18 +12,15 @@ app.listen(config.app.port, async () => {
   try {
     await prisma.$connect();
     
-    const userTourRelation = await prisma.user.findFirst({
-      select: {
-        user_tour_purchase: {
-          select: {
-            tour: true,
-          },
-        },
+    const museums = await prisma.museum.findMany({
+      where: {
+        main_tour_id: {
+          not: null
+        }
       }
     });
     
-    const userPurchasedTours = userTourRelation?.user_tour_purchase.map((purchasedTour) => purchasedTour.tour)
-    console.log(userPurchasedTours);
+    console.log(museums);
     
     console.log('\n---[Connected to database]---');
     console.log(`\n\n---[Listening on port ${config.app.port}]---\n`);

--- a/src/routes/museums.routes.ts
+++ b/src/routes/museums.routes.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { get } from "http";
+import { editMuseumController, getAllMuseumsController, getMuseumByIdController } from "../controllers/museums.controllers";
+
+const router = Router();
+
+router.get("/", getAllMuseumsController);
+router.get("/:id", getMuseumByIdController);
+router.patch("/:id", editMuseumController);
+
+export default router;

--- a/src/routes/museums.routes.ts
+++ b/src/routes/museums.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { get } from "http";
-import { createMuseumController, editMuseumController, getAllMuseumsController, getMuseumByIdController } from "../controllers/museums.controllers";
+import { createMuseumController, deleteMuseumController, editMuseumController, getAllMuseumsController, getMuseumByIdController } from "../controllers/museums.controllers";
 
 const router = Router();
 
@@ -8,5 +8,6 @@ router.get("/", getAllMuseumsController);
 router.get("/:id", getMuseumByIdController);
 router.post("/", createMuseumController);
 router.patch("/:id", editMuseumController);
+router.delete("/:id", deleteMuseumController);
 
 export default router;

--- a/src/routes/museums.routes.ts
+++ b/src/routes/museums.routes.ts
@@ -1,11 +1,12 @@
 import { Router } from "express";
 import { get } from "http";
-import { editMuseumController, getAllMuseumsController, getMuseumByIdController } from "../controllers/museums.controllers";
+import { createMuseumController, editMuseumController, getAllMuseumsController, getMuseumByIdController } from "../controllers/museums.controllers";
 
 const router = Router();
 
 router.get("/", getAllMuseumsController);
 router.get("/:id", getMuseumByIdController);
+router.post("/", createMuseumController);
 router.patch("/:id", editMuseumController);
 
 export default router;

--- a/src/types/ResponseData.ts
+++ b/src/types/ResponseData.ts
@@ -1,5 +1,6 @@
 export interface ResponseData {
   ok: boolean;
   message: string;
+  errors?: string[];
   data?: any;
 }

--- a/src/types/museums/ZodSchemas.ts
+++ b/src/types/museums/ZodSchemas.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const EditMuseumSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  address_name: z.string(),
+  main_photo: z.string(),
+  main_tour_id: z.string(),
+}).partial();

--- a/src/types/museums/ZodSchemas.ts
+++ b/src/types/museums/ZodSchemas.ts
@@ -1,9 +1,12 @@
 import { z } from "zod";
 
-export const EditMuseumSchema = z.object({
+
+export const CreateMuseumSchema = z.object({
   name: z.string(),
   description: z.string(),
   address_name: z.string(),
   main_photo: z.string(),
-  main_tour_id: z.string(),
-}).partial();
+  main_tour_id: z.string().optional(),
+});
+
+export const EditMuseumSchema = CreateMuseumSchema.partial();

--- a/src/utils/controllerUtils.ts
+++ b/src/utils/controllerUtils.ts
@@ -1,0 +1,34 @@
+import { Response } from "express";
+import { z } from "zod";
+import { ResponseData } from "../types/ResponseData";
+
+export const validateIdAndRespond = (res: Response, id: string) => {
+  const idValidation = z.string().safeParse(id);
+  if (!idValidation.success)
+    return res.status(400).json({
+      ok: false,
+      message: "Invalid id",
+      errors: idValidation.error.format(),
+    } as unknown as ResponseData);
+  return idValidation.data;
+}
+
+export const notFoundResponse = (res: Response, entity: string) => res.status(404).json({
+  ok: false,
+  message: `${entity} not found`,
+} as ResponseData);
+
+export const invalidBodyResponse = (res: Response, errors: z.ZodError) => res.status(400).json({
+  ok: false,
+  message: "Invalid body",
+  errors: errors.formErrors.fieldErrors,
+} as unknown as ResponseData);
+
+export const validateEmptyBody = (body: any): boolean => {
+  return Object.keys(body).length === 0;
+};
+
+export const emptyBodyResponse = (res: Response) => res.status(400).json({
+  ok: false,
+  message: "At least one field is required",
+} as ResponseData);


### PR DESCRIPTION
## ¿Qué tipo de PR es este?

- [x] Funcionalidad

## Descripción
This pull request introduces a new feature for managing museums in the application, including routes, controllers, and utility functions. The most important changes include the addition of new routes for museum-related operations, the implementation of controllers to handle these operations, and the creation of utility functions for validation and error handling.

### New Feature: Museum Management

* **Routes:**
  * Added new routes for museum operations in `src/routes/museums.routes.ts`, including endpoints for creating, reading, updating, and deleting museums.
  * Updated `src/app.ts` to include the new museum routes. [[1]](diffhunk://#diff-841254fe75488c1bd4cd7f68f00b4be0e48dcfbc4a16b45847b68295e0e3b27bR16-R17) [[2]](diffhunk://#diff-841254fe75488c1bd4cd7f68f00b4be0e48dcfbc4a16b45847b68295e0e3b27bR58)

* **Controllers:**
  * Implemented controllers in `src/controllers/museums.controllers.ts` to handle CRUD operations for museums. These include `getAllMuseumsController`, `getMuseumByIdController`, `createMuseumController`, `editMuseumController`, and `deleteMuseumController`.

* **Utilities:**
  * Added utility functions in `src/utils/controllerUtils.ts` for validation and error handling, such as `validateIdAndRespond`, `notFoundResponse`, `invalidBodyResponse`, `validateEmptyBody`, and `emptyBodyResponse`.

* **Schemas:**
  * Defined Zod schemas for museum data validation in `src/types/museums/ZodSchemas.ts`, including `CreateMuseumSchema` and `EditMuseumSchema`.

* **Types:**
  * Updated `ResponseData` type in `src/types/ResponseData.ts` to include an optional `errors` field for better error reporting.