### PR TITLE
fix: handle null values in editMuseumController and update main_tour_…

### DIFF
--- a/src/controllers/museums.controllers.ts
+++ b/src/controllers/museums.controllers.ts
@@ -79,7 +79,9 @@ export const editMuseumController = async (req: Request, res: Response) => {
     (acc, key) => {
       const typedKey = key as keyof typeof bodyValidation.data;
       if (bodyValidation.data[typedKey] !== undefined) {
-        acc[typedKey] = bodyValidation.data[typedKey];
+        if (bodyValidation.data[typedKey] !== null) {
+          acc[typedKey] = bodyValidation.data[typedKey] as string | undefined;
+        }
       }
       return acc;
     },

--- a/src/types/museums/ZodSchemas.ts
+++ b/src/types/museums/ZodSchemas.ts
@@ -5,7 +5,7 @@ export const CreateMuseumSchema = z.object({
   description: z.string().min(10),
   address_name: z.string().min(10),
   main_photo: z.string().url(),
-  main_tour_id: z.string().uuid().optional(),
+  main_tour_id: z.string().uuid().optional().nullable(),
 });
 
 // permit partial updates to patch a record


### PR DESCRIPTION
…id schema to be nullable

## ¿Qué tipo de PR es este?

- [x] Refactorización
- [ ] Funcionalidad
- [ ] Corrección de error
- [ ] Optimización
- [ ] Actualización de documentación

## Descripción
This pull request includes changes to the `src/controllers/museums.controllers.ts` and `src/types/museums/ZodSchemas.ts` files to improve the handling of nullable fields and ensure data integrity.

Improvements to data handling:

* [`src/controllers/museums.controllers.ts`](diffhunk://#diff-b357510408064f3f244c5257e5765286926178902e21bfd055b2afd775a7e0c1L82-R84): Modified the `editMuseumController` to check for `null` values in addition to `undefined` values before assigning them to the accumulator object. This ensures that `null` values are not mistakenly processed as valid data.

Schema validation updates:

* [`src/types/museums/ZodSchemas.ts`](diffhunk://#diff-4ddf4584226387f39f33fc4fc366bd295072d079c43aa0206561645f88d383e7L8-R8): Updated the `CreateMuseumSchema` to allow the `main_tour_id` field to be `null` in addition to being optional. This change ensures that the schema correctly handles cases where `main_tour_id` is intentionally set to `null`.