### PR TITLE
feat: add is_open field to OpenHour model for better availability tra…

### DIFF
--- a/prisma/migrations/20250218043409_add_is_open_field_to_open_hour_model/migration.sql
+++ b/prisma/migrations/20250218043409_add_is_open_field_to_open_hour_model/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "OpenHour" ADD COLUMN     "is_open" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -192,6 +192,7 @@ model Review {
 
 model OpenHour {
   id         String   @id @default(uuid())
+  is_open    Boolean  @default(false)
   day        Day
   open_time  String
   close_time String


### PR DESCRIPTION
…cking

## ¿Qué tipo de PR es este?

- [x] Refactorización
- [ ] Funcionalidad
- [ ] Corrección de error
- [ ] Optimización
- [ ] Actualización de documentación

## Descripción
This pull request includes changes to the `OpenHour` model in the Prisma schema and its corresponding migration file to add a new `is_open` field. The most important changes are:

Database schema changes:

* [`prisma/migrations/20250218043409_add_is_open_field_to_open_hour_model/migration.sql`](diffhunk://#diff-0a5a3e341f41a4a6955afa01968305fca16d86b6da88b23b3fa51eac2f72172fR1-R2): Added a new `is_open` column of type BOOLEAN with a default value of `false` to the `OpenHour` table.

Model updates:

* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR195): Updated the `OpenHour` model to include the new `is_open` field with a default value of `false`.