### PR TITLE
Muvi 158 back crud de carrusel

### DIFF
--- a/prisma/migrations/20250304013115_add_models_for_landing_information_management/migration.sql
+++ b/prisma/migrations/20250304013115_add_models_for_landing_information_management/migration.sql
@@ -1,0 +1,72 @@
+-- CreateEnum
+CREATE TYPE "CopyType" AS ENUM ('HEADER', 'PARAGRAPH', 'BUTTON', 'SUBTITLE', 'LINK', 'CALLOUT');
+
+-- CreateTable
+CREATE TABLE "Page" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Page_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Carrousel" (
+    "id" TEXT NOT NULL,
+    "page_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Carrousel_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Slide" (
+    "id" TEXT NOT NULL,
+    "carrousel_id" TEXT NOT NULL,
+    "index" INTEGER NOT NULL,
+    "image_url" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Slide_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Copy" (
+    "id" TEXT NOT NULL,
+    "entity_id" TEXT NOT NULL,
+    "parent_id" TEXT,
+    "type" "CopyType" NOT NULL,
+    "content" TEXT NOT NULL,
+    "weight" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Copy_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Carrousel_page_id_idx" ON "Carrousel"("page_id");
+
+-- CreateIndex
+CREATE INDEX "Slide_carrousel_id_idx" ON "Slide"("carrousel_id");
+
+-- CreateIndex
+CREATE INDEX "Copy_entity_id_idx" ON "Copy"("entity_id");
+
+-- CreateIndex
+CREATE INDEX "Copy_parent_id_idx" ON "Copy"("parent_id");
+
+-- AddForeignKey
+ALTER TABLE "Carrousel" ADD CONSTRAINT "Carrousel_page_id_fkey" FOREIGN KEY ("page_id") REFERENCES "Page"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Slide" ADD CONSTRAINT "Slide_carrousel_id_fkey" FOREIGN KEY ("carrousel_id") REFERENCES "Carrousel"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Copy" ADD CONSTRAINT "Copy_entity_id_fkey" FOREIGN KEY ("entity_id") REFERENCES "Page"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250305024905_update_copy_relation/migration.sql
+++ b/prisma/migrations/20250305024905_update_copy_relation/migration.sql
@@ -1,0 +1,2 @@
+-- DropForeignKey
+ALTER TABLE "Copy" DROP CONSTRAINT "Copy_entity_id_fkey";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -230,7 +230,6 @@ model Page {
   updated_at  DateTime    @updatedAt
 
   // Relaciones
-  copies      Copy[]
   carousels   Carrousel[]
 }
 
@@ -283,8 +282,6 @@ model Copy {
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
 
-  // Relaciones
-  page Page @relation(fields: [entity_id], references: [id], onDelete: Cascade)
 
   @@index([entity_id])
   @@index([parent_id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -221,3 +221,71 @@ model TourTag {
 
   @@id([tour_id, tag_id]) // Primary key compuesta
 }
+
+model Page {
+  id          String      @id @default(uuid())
+  name        String
+  description String
+  created_at  DateTime    @default(now())
+  updated_at  DateTime    @updatedAt
+
+  // Relaciones
+  copies      Copy[]
+  carousels   Carrousel[]
+}
+
+model Carrousel {
+  id          String   @id @default(uuid())
+  page_id     String
+  name        String
+  description String
+  created_at  DateTime @default(now())
+  updated_at  DateTime @updatedAt
+
+  // Relaciones
+  page   Page    @relation(fields: [page_id], references: [id], onDelete: Cascade)
+  slides Slide[]
+
+  @@index([page_id])
+}
+
+model Slide {
+  id           String   @id @default(uuid())
+  carrousel_id String
+  index        Int
+  image_url    String
+  created_at   DateTime @default(now())
+  updated_at   DateTime @updatedAt
+
+  // Relaciones
+  carrousel Carrousel @relation(fields: [carrousel_id], references: [id], onDelete: Cascade)
+
+  @@index([carrousel_id])
+}
+
+// Definición del enum para los tipos de copia
+enum CopyType {
+  HEADER
+  PARAGRAPH
+  BUTTON
+  SUBTITLE
+  LINK
+  CALLOUT
+}
+
+model Copy {
+  id         String   @id @default(uuid())
+  entity_id  String
+  parent_id  String?
+  type       CopyType
+  content    String
+  weight     String   // Para orden/prioridad
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
+
+  // Relaciones
+  page Page @relation(fields: [entity_id], references: [id], onDelete: Cascade)
+
+  @@index([entity_id])
+  @@index([parent_id])
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -5,6 +5,10 @@ const prisma = new PrismaClient();
 
 async function main() {
   // Limpia la base de datos antes de insertar nuevos datos
+  await prisma.copy.deleteMany();
+  await prisma.slide.deleteMany();
+  await prisma.carrousel.deleteMany();
+  await prisma.page.deleteMany();
   await prisma.tourTag.deleteMany();
   await prisma.tour.deleteMany();
   await prisma.tag.deleteMany();
@@ -153,6 +157,153 @@ async function main() {
       },
     }),
   ]);
+
+  // Crear la landing page principal
+  const landingPage = await prisma.page.create({
+    data: {
+      name: 'Landing Page Principal',
+      description: 'Página de inicio del sitio web del museo'
+    }
+  });
+
+  // Crear algunos textos (copies) para la página de landing
+  await Promise.all([
+    prisma.copy.create({
+      data: {
+        entity_id: landingPage.id,
+        type: 'HEADER',
+        content: 'Bienvenidos al Museo',
+        weight: '1'
+      }
+    }),
+    prisma.copy.create({
+      data: {
+        entity_id: landingPage.id,
+        type: 'PARAGRAPH',
+        content: 'Descubre nuestras exhibiciones únicas y tours virtuales',
+        weight: '2'
+      }
+    }),
+    prisma.copy.create({
+      data: {
+        entity_id: landingPage.id,
+        type: 'BUTTON',
+        content: 'Explorar Tours',
+        weight: '3'
+      }
+    })
+  ]);
+
+  // Crear carrusel principal
+  const mainCarousel = await prisma.carrousel.create({
+    data: {
+      page_id: landingPage.id,
+      name: 'Novedades',
+      description: 'Carrusel de novedades del museo'
+    }
+  });
+
+  // Crear slides para el carrusel
+  const slides = await Promise.all([
+    prisma.slide.create({
+      data: {
+        carrousel_id: mainCarousel.id,
+        index: 0,
+        image_url: 'https://placehold.co/800x400/orange/white?text=Exhibición+Especial'
+      }
+    }),
+    prisma.slide.create({
+      data: {
+        carrousel_id: mainCarousel.id,
+        index: 1,
+        image_url: 'https://placehold.co/800x400/blue/white?text=Tours+Virtuales'
+      }
+    }),
+    prisma.slide.create({
+      data: {
+        carrousel_id: mainCarousel.id,
+        index: 2,
+        image_url: 'https://placehold.co/800x400/green/white?text=Eventos+Especiales'
+      }
+    })
+  ]);
+
+  console.log('Seeding base data completed');
+  
+  // Después de crear los slides, ahora creamos los títulos y descripciones como copies
+  const slideCopies = [];
+  
+  // Títulos y descripciones para el primer slide
+  slideCopies.push(
+    prisma.copy.create({
+      data: {
+        entity_id: slides[0].id,
+        type: 'HEADER',
+        content: 'Nueva Exhibición: Dinosaurios',
+        weight: '1'
+      }
+    })
+  );
+  
+  slideCopies.push(
+    prisma.copy.create({
+      data: {
+        entity_id: slides[0].id,
+        type: 'PARAGRAPH',
+        content: 'Descubre los fósiles más impresionantes de la era mesozoica',
+        weight: '2'
+      }
+    })
+  );
+  
+  // Títulos y descripciones para el segundo slide
+  slideCopies.push(
+    prisma.copy.create({
+      data: {
+        entity_id: slides[1].id,
+        type: 'HEADER',
+        content: 'Tours Virtuales 360°',
+        weight: '1'
+      }
+    })
+  );
+  
+  slideCopies.push(
+    prisma.copy.create({
+      data: {
+        entity_id: slides[1].id,
+        type: 'PARAGRAPH',
+        content: 'Explora el museo desde la comodidad de tu hogar',
+        weight: '2'
+      }
+    })
+  );
+  
+  // Títulos y descripciones para el tercer slide
+  slideCopies.push(
+    prisma.copy.create({
+      data: {
+        entity_id: slides[2].id,
+        type: 'HEADER',
+        content: 'Noche en el Museo',
+        weight: '1'
+      }
+    })
+  );
+  
+  slideCopies.push(
+    prisma.copy.create({
+      data: {
+        entity_id: slides[2].id,
+        type: 'PARAGRAPH',
+        content: 'Visitas nocturnas especiales cada fin de semana',
+        weight: '2'
+      }
+    })
+  );
+  
+  // Ejecutar todas las operaciones de copia de slides
+  await Promise.all(slideCopies);
 
   console.log('Seeding executed successfully');
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import storageRoutes from "./routes/storage.routes";
 import mpWebHookRoutes from "./routes/webhook.routes";
 import orderRoutes from "./routes/order.routes";
 import tagRoutes from './routes/tag.routes';
+import carouselRoutes from './routes/carousel.routes';
 // middlewares
 import { AuthMiddleware } from "./middlewares";
 
@@ -64,6 +65,7 @@ app.use("/api/museums", museumsRoutes);
 app.use("/api/storage", storageRoutes);
 app.use("/api/orders", orderRoutes);
 app.use('/api/tags', tagRoutes);
+app.use('/api/carousels', carouselRoutes);
 
 app.get("/", AuthMiddleware, (req: Request, res: Response) => {
   res.send(JSON.stringify(req.user));

--- a/src/controllers/carousel.controllers.ts
+++ b/src/controllers/carousel.controllers.ts
@@ -1,0 +1,367 @@
+import { Request, Response } from "express";
+import prisma from "../prisma";
+import { z } from "zod";
+import { CarouselRequestSchema } from "../types/carousel/ZodSchemas";
+import { handleControllerError } from "../utils/controllerUtils";
+import { ResponseData } from "../types/ResponseData";
+
+export const getCarousels = async (req: Request, res: Response) => {
+  try {
+    // Primero obtenemos todos los carruseles con sus slides
+    const carousels = await prisma.carrousel.findMany({
+      include: {
+        slides: {
+          orderBy: {
+            index: "asc",
+          },
+        },
+      },
+    });
+
+    // Para cada carrusel, procesamos sus slides para incluir título y descripción
+    const carouselsWithDetails = await Promise.all(
+      carousels.map(async (carousel) => {
+        const slidesWithDetails = await Promise.all(
+          carousel.slides.map(async (slide) => {
+            // Obtener los copies asociados a este slide
+            const copies = await prisma.copy.findMany({
+              where: { entity_id: slide.id },
+            });
+
+            // Buscar el título (HEADER) y la descripción (PARAGRAPH)
+            const titleCopy = copies.find((copy) => copy.type === "HEADER");
+            const descriptionCopy = copies.find(
+              (copy) => copy.type === "PARAGRAPH"
+            );
+
+            // Devolver el slide con título y descripción
+            return {
+              ...slide,
+              title: titleCopy?.content || "",
+              description: descriptionCopy?.content || "",
+            };
+          })
+        );
+
+        // Devolver el carrusel con los slides procesados
+        return {
+          ...carousel,
+          slides: slidesWithDetails,
+        };
+      })
+    );
+
+    return res.status(200).json({
+      ok: true,
+      message: "Carousels retrieved successfully",
+      data: carouselsWithDetails,
+    } as ResponseData);
+  } catch (error) {
+    return handleControllerError(error, res);
+  }
+};
+
+export const getCarouselById = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+
+    const carousel = await prisma.carrousel.findUnique({
+      where: { id },
+      include: {
+        slides: {
+          orderBy: {
+            index: "asc",
+          },
+        },
+      },
+    });
+
+    if (!carousel) {
+      return res.status(404).json({
+        ok: false,
+        message: "Carousel not found",
+      } as ResponseData);
+    }
+
+    // Buscar los Copies asociados a cada slide para obtener título y descripción
+    const slidesWithDetails = await Promise.all(
+      carousel.slides.map(async (slide) => {
+        const copies = await prisma.copy.findMany({
+          where: { entity_id: slide.id },
+        });
+
+        const titleCopy = copies.find((copy) => copy.type === "HEADER");
+        const descriptionCopy = copies.find(
+          (copy) => copy.type === "PARAGRAPH"
+        );
+
+        return {
+          ...slide,
+          title: titleCopy?.content || "",
+          description: descriptionCopy?.content || "",
+        };
+      })
+    );
+
+    return res.status(200).json({
+      ok: true,
+      message: "Carousel retrieved successfully",
+      data: {
+        ...carousel,
+        slides: slidesWithDetails,
+      },
+    } as ResponseData);
+  } catch (error) {
+    return handleControllerError(error, res);
+  }
+};
+
+interface SlideWithTitleDesc {
+  index: number;
+  image_url: string;
+  title?: string;
+  description?: string;
+}
+
+export const createCarousel = async (req: Request, res: Response) => {
+  try {
+    // Validar el body de la solicitud
+    const validatedData = CarouselRequestSchema.parse(req.body);
+    const { page_id, name, description, slides } = validatedData;
+
+    // Verificar que la página existe
+    const pageExists = await prisma.page.findUnique({
+      where: { id: page_id },
+    });
+
+    if (!pageExists) {
+      return res.status(404).json({
+        ok: false,
+        message: "Page not found",
+      } as ResponseData);
+    }
+
+    // Crear el carrusel con sus slides en una única transacción
+    const result = await prisma.$transaction(async (tx) => {
+      // Crear el carrusel
+      const carousel = await tx.carrousel.create({
+        data: {
+          page_id,
+          name,
+          description,
+        },
+      });
+
+      // Crear los slides
+      const createdSlides = await Promise.all(
+        slides.map(async (slide: SlideWithTitleDesc) => {
+          // Crear el slide
+          const createdSlide = await tx.slide.create({
+            data: {
+              carrousel_id: carousel.id,
+              index: slide.index,
+              image_url: slide.image_url,
+            },
+          });
+
+          // Crear el Copy para el título si existe
+          if (slide.title) {
+            await tx.copy.create({
+              data: {
+                entity_id: createdSlide.id,
+                type: "HEADER",
+                content: slide.title,
+                weight: "1",
+              },
+            });
+          }
+
+          // Crear el Copy para la descripción si existe
+          if (slide.description) {
+            await tx.copy.create({
+              data: {
+                entity_id: createdSlide.id,
+                type: "PARAGRAPH",
+                content: slide.description,
+                weight: "2",
+              },
+            });
+          }
+
+          return {
+            ...createdSlide,
+            title: slide.title || "",
+            description: slide.description || "",
+          };
+        })
+      );
+
+      return {
+        ...carousel,
+        slides: createdSlides,
+      };
+    });
+
+    return res.status(201).json({
+      ok: true,
+      message: "Carousel created successfully",
+      data: result,
+    } as ResponseData);
+  } catch (error) {
+    return handleControllerError(error, res);
+  }
+};
+
+export const updateCarousel = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const validatedData = CarouselRequestSchema.parse(req.body);
+    const { name, description, slides, page_id } = validatedData;
+
+    // Verificar que el carrusel existe
+    const carouselExists = await prisma.carrousel.findUnique({
+      where: { id },
+      include: {
+        slides: true,
+      },
+    });
+
+    if (!carouselExists) {
+      return res.status(404).json({
+        ok: false,
+        message: "Carousel not found",
+      } as ResponseData);
+    }
+
+    // Actualizar el carrusel con sus slides en una única transacción
+    const result = await prisma.$transaction(async (tx) => {
+      // Actualizar el carrusel
+      const carousel = await tx.carrousel.update({
+        where: { id },
+        data: {
+          page_id,
+          name,
+          description,
+        },
+      });
+
+      // Eliminar slides existentes y sus copies asociados
+      for (const slide of carouselExists.slides) {
+        // Eliminar copies asociados al slide
+        await tx.copy.deleteMany({
+          where: { entity_id: slide.id },
+        });
+      }
+
+      // Eliminar todos los slides actuales
+      await tx.slide.deleteMany({
+        where: { carrousel_id: id },
+      });
+
+      // Crear los nuevos slides
+      const createdSlides = await Promise.all(
+        slides.map(async (slide: SlideWithTitleDesc) => {
+          // Crear el slide
+          const createdSlide = await tx.slide.create({
+            data: {
+              carrousel_id: carousel.id,
+              index: slide.index,
+              image_url: slide.image_url,
+            },
+          });
+
+          // Crear el Copy para el título si existe
+          if (slide.title) {
+            await tx.copy.create({
+              data: {
+                entity_id: createdSlide.id,
+                type: "HEADER",
+                content: slide.title,
+                weight: "1",
+              },
+            });
+          }
+
+          // Crear el Copy para la descripción si existe
+          if (slide.description) {
+            await tx.copy.create({
+              data: {
+                entity_id: createdSlide.id,
+                type: "PARAGRAPH",
+                content: slide.description,
+                weight: "2",
+              },
+            });
+          }
+
+          return {
+            ...createdSlide,
+            title: slide.title || "",
+            description: slide.description || "",
+          };
+        })
+      );
+
+      return {
+        ...carousel,
+        slides: createdSlides,
+      };
+    });
+
+    return res.status(200).json({
+      ok: true,
+      message: "Carousel updated successfully",
+      data: result,
+    } as ResponseData);
+  } catch (error) {
+    return handleControllerError(error, res);
+  }
+};
+
+export const deleteCarousel = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+
+    // Verificar que el carrusel existe
+    const carouselExists = await prisma.carrousel.findUnique({
+      where: { id },
+      include: {
+        slides: true,
+      },
+    });
+
+    if (!carouselExists) {
+      return res.status(404).json({
+        ok: false,
+        message: "Carousel not found",
+      } as ResponseData);
+    }
+
+    // Eliminar el carrusel y sus slides en una única transacción
+    await prisma.$transaction(async (tx) => {
+      // Eliminar copies asociados a cada slide
+      for (const slide of carouselExists.slides) {
+        await tx.copy.deleteMany({
+          where: { entity_id: slide.id },
+        });
+      }
+
+      // Eliminar slides
+      await tx.slide.deleteMany({
+        where: { carrousel_id: id },
+      });
+
+      // Eliminar carrusel
+      await tx.carrousel.delete({
+        where: { id },
+      });
+    });
+
+    return res.status(200).json({
+      ok: true,
+      message: "Carousel deleted successfully",
+    } as ResponseData);
+  } catch (error) {
+    return handleControllerError(error, res);
+  }
+};

--- a/src/controllers/carousel.controllers.ts
+++ b/src/controllers/carousel.controllers.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 import prisma from "../prisma";
 import { z } from "zod";
 import { CarouselRequestSchema } from "../types/carousel/ZodSchemas";
-import { handleControllerError } from "../utils/controllerUtils";
+import { handleControllerError, notFoundResponse } from "../utils/controllerUtils";
 import { ResponseData } from "../types/ResponseData";
 
 export const getCarousels = async (req: Request, res: Response) => {
@@ -134,12 +134,7 @@ export const createCarousel = async (req: Request, res: Response) => {
       where: { id: page_id },
     });
 
-    if (!pageExists) {
-      return res.status(404).json({
-        ok: false,
-        message: "Page not found",
-      } as ResponseData);
-    }
+    if (!pageExists) return notFoundResponse(res, "Page");
 
     // Crear el carrusel con sus slides en una única transacción
     const result = await prisma.$transaction(async (tx) => {
@@ -226,12 +221,14 @@ export const updateCarousel = async (req: Request, res: Response) => {
       },
     });
 
-    if (!carouselExists) {
-      return res.status(404).json({
-        ok: false,
-        message: "Carousel not found",
-      } as ResponseData);
-    }
+    if (!carouselExists) return notFoundResponse(res, "Carousel");
+
+    // Verificar que la página existe
+    const pageExists = await prisma.page.findUnique({
+      where: { id: page_id },
+    });
+
+    if (!pageExists) return notFoundResponse(res, "Page");
 
     // Actualizar el carrusel con sus slides en una única transacción
     const result = await prisma.$transaction(async (tx) => {
@@ -330,12 +327,7 @@ export const deleteCarousel = async (req: Request, res: Response) => {
       },
     });
 
-    if (!carouselExists) {
-      return res.status(404).json({
-        ok: false,
-        message: "Carousel not found",
-      } as ResponseData);
-    }
+    if (!carouselExists) return notFoundResponse(res, "Carousel");
 
     // Eliminar el carrusel y sus slides en una única transacción
     await prisma.$transaction(async (tx) => {

--- a/src/routes/carousel.routes.ts
+++ b/src/routes/carousel.routes.ts
@@ -1,0 +1,47 @@
+import { Router } from "express";
+import {
+  getCarousels,
+  getCarouselById,
+  createCarousel,
+  updateCarousel,
+  deleteCarousel,
+} from "../controllers/carousel.controllers";
+
+const router = Router();
+
+/**
+ * @route GET /api/carousels
+ * @desc Get all carousels
+ * @access Public
+ */
+router.get("/", getCarousels);
+
+/**
+ * @route GET /api/carousels/:id
+ * @desc Get carousel by ID
+ * @access Public
+ */
+router.get("/:id", getCarouselById);
+
+/**
+ * @route POST /api/carousels
+ * @desc Create a new carousel
+ * @access Admin
+ */
+router.post("/", createCarousel);
+
+/**
+ * @route PUT /api/carousels/:id
+ * @desc Update a carousel
+ * @access Admin
+ */
+router.put("/:id", updateCarousel);
+
+/**
+ * @route DELETE /api/carousels/:id
+ * @desc Delete a carousel
+ * @access Admin
+ */
+router.delete("/:id", deleteCarousel);
+
+export default router;

--- a/src/types/carousel/ZodSchemas.ts
+++ b/src/types/carousel/ZodSchemas.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+// Esquema para validar un Slide en la solicitud
+export const SlideRequestSchema = z.object({
+  index: z.number().int().nonnegative(),
+  image_url: z.string().url(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+});
+
+// Esquema para validar la solicitud completa del Carousel
+export const CarouselRequestSchema = z.object({
+  page_id: z.string().uuid(),
+  name: z.string().min(1),
+  description: z.string(),
+  slides: z.array(SlideRequestSchema),
+});
+
+// Tipos TypeScript derivados de los esquemas Zod
+export type SlideRequest = z.infer<typeof SlideRequestSchema>;
+export type CarouselRequest = z.infer<typeof CarouselRequestSchema>;

--- a/src/utils/controllerUtils.ts
+++ b/src/utils/controllerUtils.ts
@@ -41,3 +41,21 @@ export const operationErrorResponse = (res: Response) => {
     message: "Operation error",
   } as ResponseData);
 }
+
+export const handleControllerError = (error: unknown, res: Response) => {
+  console.error('Controller error:', error);
+  
+  if (error instanceof z.ZodError) {
+    return invalidBodyResponse(res, error);
+  }
+  
+  // Si el error tiene un mensaje específico
+  if (error instanceof Error) {
+    return res.status(500).json({
+      ok: false,
+      message: `Operation error: ${error.message}`
+    });
+  }
+  
+  return operationErrorResponse(res);
+};


### PR DESCRIPTION
## ¿Qué tipo de PR es este?

- [ ] Refactorización
- [x] Funcionalidad
- [ ] Corrección de error
- [ ] Optimización
- [ ] Actualización de documentación

## Descripción
Implementación de CRUD para el modelo de carrusel, que permite la gestión de slides en la landing page. 

Los endpoints implementados permiten:
- Crear carruseles con múltiples slides
- Obtener la lista de carruseles existentes
- Actualizar carruseles y sus slides
- Eliminar carruseles

## Recursos útiles
- El modelo de datos incluye: Page, Carrousel, Slide y Copy
- Se implementó una relación flexible para el modelo Copy que permite asociarlo con distintas entidades
- Se agregaron seeds para probar la funcionalidad

### Pruebas
1. Ejecutar las migraciones: `npx prisma migrate dev`
2. Ejecutar el seed: `npm run seed`
3. Probar los endpoints con Postman:
   - GET `/api/carousels` - Listar todos los carruseles
   - GET `/api/carousels/:id` - Obtener un carrusel específico
   - POST `/api/carousels` - Crear un nuevo carrusel con slides
   - PUT `/api/carousels/:id` - Actualizar un carrusel existente
   - DELETE `/api/carousels/:id` - Eliminar un carrusel
