### PR TITLE
Muvi 174 fullstack manejo de tours acreditables

### DIFF
--- a/prisma/migrations/20250605231307_add_accreditable_fields_to_tour/migration.sql
+++ b/prisma/migrations/20250605231307_add_accreditable_fields_to_tour/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Tour" ADD COLUMN     "accreditable_hours" DECIMAL(5,2),
+ADD COLUMN     "is_accreditable" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -144,6 +144,10 @@ model Tour {
   url         String
   image_url   String
 
+  // Acreditaciones
+  is_accreditable    Boolean @default(false)
+  accreditable_hours Decimal? @db.Decimal(5, 2)
+
   museum_id String @default("")
   museum    Museum @relation(fields: [museum_id], references: [id], onDelete: Cascade)
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -120,8 +120,7 @@ async function main() {
         name: "Museo Universitario Fernando del Paso",
         description:
           "El Museo Fernando del Paso es un espacio dedicado a la obra y legado del destacado escritor, pintor y diplomático mexicano. Alberga una colección permanente de manuscritos, pinturas y objetos personales del autor, ofreciendo a los visitantes una inmersión en su universo creativo.",
-        address_name:
-          "C. 27 de Septiembre 119, Centro, 28000 Colima, Col.",
+        address_name: "C. 27 de Septiembre 119, Centro, 28000 Colima, Col.",
         main_photo:
           "https://res.cloudinary.com/dstcjr7lh/image/upload/v1746495993/muvi/gnavoznxcxvvuvhv3rc3.jpg",
         latitude: 19.244015338719084,
@@ -170,7 +169,7 @@ async function main() {
               open_time: null,
               close_time: null,
             },
-          ]
+          ],
         },
       },
     }),
@@ -179,7 +178,7 @@ async function main() {
   // URL de ejemplo para los Tours
   const tourUrl = "https://kuula.co/share/collection/example";
 
-  // Crear Tours con múltiples Tags
+  // Crear Tours con múltiples Tags y NUEVOS CAMPOS DE ACREDITACIÓN
   const tours = await Promise.all([
     prisma.tour.create({
       data: {
@@ -188,8 +187,12 @@ async function main() {
         price: 80,
         stars: 0,
         url: "https://kuula.co/share/collection/7ZYnc?logo=-1&info=0&fs=1&vr=1&thumbs=3&alpha=0.77&inst=es",
-        image_url: "https://res.cloudinary.com/dxdme71no/image/upload/v1748024618/qxoo2s1eldiajxl8mh4s.png",
+        image_url:
+          "https://res.cloudinary.com/dxdme71no/image/upload/v1748024618/qxoo2s1eldiajxl8mh4s.png",
         museum_id: museums[0].id,
+        // NUEVOS CAMPOS DE ACREDITACIÓN
+        is_accreditable: true,
+        accreditable_hours: 2.0,
         tags: {
           create: [
             { tag: { connect: { id: tags[0].id } } }, // Universitario
@@ -201,12 +204,17 @@ async function main() {
     prisma.tour.create({
       data: {
         name: "Instalaciones Fernando del Paso",
-        description: 'El primer recorrido virtual en el museo de arte emergente "Fernando del Paso"',
+        description:
+          'El primer recorrido virtual en el museo de arte emergente "Fernando del Paso"',
         price: 80,
         stars: 0,
         url: "https://kuula.co/share/5TCxb/collection/7cp8f?logo=-1&info=0&fs=1&vr=1&thumbs=3&alpha=0.77&inst=es",
-        image_url: "https://res.cloudinary.com/dstcjr7lh/image/upload/v1746495993/muvi/gnavoznxcxvvuvhv3rc3.jpg",
+        image_url:
+          "https://res.cloudinary.com/dstcjr7lh/image/upload/v1746495993/muvi/gnavoznxcxvvuvhv3rc3.jpg",
         museum_id: museums[0].id,
+        // NUEVOS CAMPOS DE ACREDITACIÓN
+        is_accreditable: false,
+        accreditable_hours: null,
         tags: {
           create: [
             { tag: { connect: { id: tags[0].id } } }, // Universitario
@@ -218,12 +226,17 @@ async function main() {
     prisma.tour.create({
       data: {
         name: "Mutante",
-        description: 'Recorrido por la colección de Mutante en el museo de arte emergente "Fernando del Paso"',
+        description:
+          'Recorrido por la colección de Mutante en el museo de arte emergente "Fernando del Paso"',
         price: 80,
         stars: 0,
         url: "https://kuula.co/share/collection/7KHM3?logo=-1&info=0&fs=1&vr=1&thumbs=3&alpha=0.77&inst=es",
-        image_url: "https://res.cloudinary.com/dxdme71no/image/upload/v1748025101/d2jlakfwlphzajwo9q28.png",
+        image_url:
+          "https://res.cloudinary.com/dxdme71no/image/upload/v1748025101/d2jlakfwlphzajwo9q28.png",
         museum_id: museums[0].id,
+        // NUEVOS CAMPOS DE ACREDITACIÓN
+        is_accreditable: true,
+        accreditable_hours: 1.5,
         tags: {
           create: [
             { tag: { connect: { id: tags[0].id } } }, // Universitario
@@ -235,12 +248,17 @@ async function main() {
     prisma.tour.create({
       data: {
         name: "Palabralma",
-        description: 'Primera colección expuesta en el museo de arte emergente "Fernando del Paso"',
+        description:
+          'Primera colección expuesta en el museo de arte emergente "Fernando del Paso"',
         price: 80,
         stars: 0,
         url: "https://kuula.co/share/collection/7cTcT?logo=-1&info=0&fs=1&vr=1&thumbs=3&alpha=0.77&inst=es",
-        image_url: "https://res.cloudinary.com/dxdme71no/image/upload/v1748025300/ewkzlvclqvw8h75iwdsc.png",
+        image_url:
+          "https://res.cloudinary.com/dxdme71no/image/upload/v1748025300/ewkzlvclqvw8h75iwdsc.png",
         museum_id: museums[0].id,
+        // NUEVOS CAMPOS DE ACREDITACIÓN
+        is_accreditable: false,
+        accreditable_hours: null,
         tags: {
           create: [
             { tag: { connect: { id: tags[0].id } } }, // Universitario
@@ -403,6 +421,16 @@ async function main() {
   await Promise.all(slideCopies);
 
   console.log("Seeding executed successfully");
+  console.log(`Created ${tours.length} tours with accreditation data:`);
+
+  // Mostrar información sobre los tours creados
+  tours.forEach((tour, index) => {
+    console.log(
+      `- ${tour.name}: ${
+        tour.is_accreditable ? "Acreditable" : "No acreditable"
+      }${tour.accreditable_hours ? ` (${tour.accreditable_hours}h)` : ""}`
+    );
+  });
 }
 
 main()

--- a/src/querys/tour.querys.ts
+++ b/src/querys/tour.querys.ts
@@ -20,6 +20,8 @@ export const TourWithoutUrlSelectQuery = {
   stars: true,       // Calificación en estrellas del tour
   image_url: true,   // URL de la imagen del tour
   museum_id: true,   // ID del museo asociado al tour
+  is_accreditable: true, // Indica si el tour es acreditable
+  accreditable_hours: true, // Horas acreditables del tour
   created_at: true,  // Fecha de creación del tour
   updated_at: true,  // Fecha de última actualización del tour
   tags: {

--- a/src/validations/tour.validations.ts
+++ b/src/validations/tour.validations.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from "zod";
 
 export const CreateTourSchema = z.object({
   name: z.string().min(3),
@@ -7,11 +7,12 @@ export const CreateTourSchema = z.object({
   url: z.string().url(),
   image_url: z.string().url(),
   museum_id: z.string().uuid(),
-  tags: z.array(z.string()).optional()
+  tags: z.array(z.string()).optional(),
+  is_accreditable: z.boolean().default(false),
+  accreditable_hours: z.number().positive().optional().nullable(),
 });
 
-// permit partial updates to patch a record
+// Permit partial updates to patch a record
 export const EditTourSchema = CreateTourSchema.partial();
-
 
 export const IdsSchema = z.array(z.string());


### PR DESCRIPTION
## ¿Qué tipo de PR es este?
- [ ] Refactorización
- [x] Funcionalidad
- [ ] Corrección de error
- [ ] Optimización
- [ ] Actualización de documentación

## Descripción
Implementación del soporte para tours acreditables en la base de datos y API. Se agregaron los campos `is_accreditable` (boolean) y `accreditable_hours` (decimal opcional) al modelo Tour. Se creó la migración correspondiente, se actualizaron las consultas para incluir los nuevos campos, se añadió validación para horas positivas y se actualizó el seed con datos de ejemplo.

## Recursos útiles
- Migración: `prisma/migrations/20250605231307_add_accreditable_fields_to_tour/`
- Esquema actualizado: `prisma/schema.prisma`

### Pruebas
1. **Verificar migración**: Ejecutar `npx prisma migrate dev` y confirmar que se aplica sin errores
2. **Probar seed**: Ejecutar `npx prisma db seed` y verificar que se crean tours con datos de acreditación
3. **Verificar API**: Hacer GET a `/api/tours` y confirmar que incluye campos `is_accreditable` y `accreditable_hours`
4. **Probar validación**: Intentar crear tour con `accreditable_hours` negativo y verificar error de validación
5. **Verificar queries**: Confirmar que todas las consultas existentes siguen funcionando con los nuevos campos
6. **Probar base de datos**: Conectar a DB y verificar estructura de tabla `Tour` actualizada